### PR TITLE
UFRGS-17 - Fixes daylight savings time info for Brazil

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -173,3 +173,7 @@ gem 'geocoder'
 gem 'redcarpet'
 gem 'epic-editor-rails'
 gem 'leaflet-rails'
+
+# for timezone info
+# useful if we keep it more up-to-date than the system packages are
+gem 'tzinfo-data'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,6 +509,8 @@ GEM
       railties (>= 3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2021.5)
+      tzinfo (>= 1.0.0)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
     uuidtools (2.1.5)
@@ -645,6 +647,7 @@ DEPENDENCIES
   translate-rails3!
   turn (= 0.8.2)
   twitter-bootstrap-rails (~> 2.2.8)
+  tzinfo-data
   uglifier (>= 1.0.3)
   valid_email (~> 0.0.10)
   vpim (~> 13.11.11)


### PR DESCRIPTION
Add the gem `tzinfo-data`.
The application is running in a server that has older time info, so the gem is more up-to-date than it.