### PR TITLE
fix: add bbb_override_default_locale metadata

### DIFF
--- a/config/initializers/bigbluebutton_rails.rb
+++ b/config/initializers/bigbluebutton_rails.rb
@@ -37,7 +37,18 @@ BigbluebuttonRails.configure do |config|
       record: ability.can?(:record_meeting, room)
     }
   end
-  
+
+  # Add custom metadata join calls
+  config.get_join_options = Proc.new do |room, user|
+    include Mconf::LocaleControllerModule
+    opts = {
+      # FIX ME: remove after team Live update bbb to version 2.4
+      "userdata-mconf_custom_language": Mconf::LocaleControllerModule.get_user_locale(user),
+      "userdata-bbb_override_default_locale": Mconf::LocaleControllerModule.get_user_locale(user),
+    }
+    opts
+  end
+
 end
 
 Rails.application.config.to_prepare do

--- a/lib/mconf/locale_controller_module.rb
+++ b/lib/mconf/locale_controller_module.rb
@@ -24,7 +24,7 @@ module Mconf
         user.locale.to_sym
 
       # session locale
-      elsif use_session and session_has_locale?(session)
+      elsif use_session && defined?(session) && session_has_locale?(session)
         session[:locale]
 
       # site locale

--- a/spec/lib/bigbluebutton_rails.rb
+++ b/spec/lib/bigbluebutton_rails.rb
@@ -81,6 +81,42 @@ describe BigbluebuttonRails do
     end
   end
 
+  describe "#get_join_options" do
+    let(:target) { BigbluebuttonRails.configuration }
+    let(:room) { FactoryGirl.create(:bigbluebutton_room) }
+
+    it { target.should respond_to(:get_join_options) }
+    it { target.get_create_options.should be_a(Proc) }
+
+    context 'sets locale' do
+      context 'when user has logged in' do
+        let(:user) { FactoryGirl.create(:user, locale: "en") }
+        let(:join_options) { target.get_join_options.call(room, user, {}) }
+        let(:locale) { Mconf::LocaleControllerModule.get_user_locale(user) }
+        # FIX ME: remove after team Live update bbb to version 2.4
+        it { expect(join_options[:"userdata-mconf_custom_language"]).to eql(locale) }
+        it { expect(join_options[:"userdata-bbb_override_default_locale"]).to eql(locale) }
+      end
+
+      context 'when user has logged in' do
+        let(:user) { FactoryGirl.create(:user, locale: "pt-br") }
+        let(:join_options) { target.get_join_options.call(room, user, {}) }
+        let(:locale) { Mconf::LocaleControllerModule.get_user_locale(user) }
+        # FIX ME: remove after team Live update bbb to version 2.4
+        it { expect(join_options[:"userdata-mconf_custom_language"]).to eql(locale) }
+        it { expect(join_options[:"userdata-bbb_override_default_locale"]).to eql(locale) }
+      end
+
+      context 'when user has not logged in' do
+        let(:join_options) { target.get_join_options.call(room, nil, {}) }
+        let(:locale) { Mconf::LocaleControllerModule.get_user_locale(nil) }
+        # FIX ME: remove after team Live update bbb to version 2.4
+        it { expect(join_options[:"userdata-mconf_custom_language"]).to eql(locale) }
+        it { expect(join_options[:"userdata-bbb_override_default_locale"]).to eql(locale) }
+      end
+    end
+  end
+
   describe "#select_server" do
     let(:target) { BigbluebuttonRails.configuration }
     let(:room) { FactoryGirl.create(:bigbluebutton_room) }


### PR DESCRIPTION
Add `userdata-bbb_override_default_locale` metadata;
Add comments FIX ME, informing the need to remove the old metadata: `userdata-mconf_custom_language`, after team Live update bbb to version 2.4;
Add tests to context `sets locale`