### PR TITLE
UFRGSP-19 Recordings banner now mentions processing time

### DIFF
--- a/app/assets/stylesheets/app/shared/_recording_list.css.scss
+++ b/app/assets/stylesheets/app/shared/_recording_list.css.scss
@@ -8,8 +8,8 @@
 
   .banner {
     .banner-wrapper {
-      width: 100%;
-      height: 50px;
+      padding: 12px;
+      text-align: center;
       background-color: $alert-danger-font
     }
 
@@ -21,7 +21,7 @@
       flex-flow: row nowrap;
       align-items: center;
       justify-content: center;
-      font-size: large;
+      font-size: $font-medium;
     
       color: white;
     }

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -1315,7 +1315,7 @@ en:
       title: Press Ctrl+C to copy the text
       success: Text copied to clipboard
     recording_list:
-      banner_expiring: "Attention! Recordings will be deleted after 6 months"
+      banner_expiring: "Be aware that recordings can take up to 24 hours to become available and are deleted after 6 months."
       created: "Created"
       created_by: "Created by"
       destroy_confirm: "Are you sure you want to permanently remove this recording?"

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -1320,7 +1320,7 @@ pt-br:
       title: Aperte Ctrl+C para copiar o texto
       success: Texto copiado para a área de transferência
     recording_list:
-      banner_expiring: "Atenção! As gravações serão deletadas após 6 meses"
+      banner_expiring: "Atenção! As gravações demoram até 24h para estarem disponíveis e são deletadas após 6 meses."
       created: "Criada"
       created_by: "Criada por"
       destroy_confirm: "Você tem certeza que deseja remover esta gravação permanentemente?"


### PR DESCRIPTION
* The banner used to warn the user that recordings will expire 60 days after the meeting. Now, not only that, but it explains that the recording can take up to 24 hours to be processed.