### PR TITLE
ELOSP-783: replace devise-async by a simpler way to send devise emails async

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ gem 'bcrypt', '~> 3.1.5'
 gem 'devise', '~> 3.5.4'
 gem 'devise-encryptable' # TODO: #1271 only while we have old station users
 gem 'cancancan', '~> 1.9'
-gem 'devise-async'
 gem 'net-ldap'
 
 # BigBlueButton integration

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,8 +176,6 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
-    devise-async (0.9.0)
-      devise (~> 3.2)
     devise-encryptable (0.2.0)
       devise (>= 2.1.0)
     diff-lcs (1.2.5)
@@ -574,7 +572,6 @@ DEPENDENCIES
   compass-rails (~> 2.0)
   database_cleaner
   devise (~> 3.5.4)
-  devise-async
   devise-encryptable
   dotenv-rails
   dotiw

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -5,11 +5,20 @@
 # 3 or later. See the LICENSE file.
 
 class DeviseMailer < Devise::Mailer
-  helper :application
+
   include Devise::Controllers::UrlHelpers
+  include Mconf::LocaleControllerModule
+
   default template_path: 'devise/mailer'
   layout 'mailers'
 
+  # override the default method used by devise to set the user's locale
+  def devise_mail(record, action, opts = {}, &block)
+    I18n.with_locale(get_user_locale(record, nil)) do
+      super
+    end
+  end
+  
   def confirmation_instructions(record, token, opts={})
     return if !record.local_auth?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ActiveRecord::Base
   ## Devise setup
   # Other available devise modules are:
   # :token_authenticatable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :async, :registerable,
+  devise :database_authenticatable, :registerable,
          :confirmable, :recoverable, :rememberable, :trackable,
          :validatable, :encryptable
   # Virtual attribute for authenticating by either username or email
@@ -298,6 +298,12 @@ class User < ActiveRecord::Base
     else
       super # Use whatever other message
     end
+  end
+
+  # Overrides a method from devise to send emails using a queue system, see:
+  # https://github.com/heartcombo/devise#activejob-integration
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver
   end
 
   # Return the list of spaces in which the user has a pending join request or invitation.

--- a/config/initializers/resque_mailer.rb
+++ b/config/initializers/resque_mailer.rb
@@ -9,28 +9,3 @@ Resque::Mailer.excluded_environments = []
 Resque::Mailer.error_handler = lambda { |mailer, message, error, action, args|
   Mconf::MailerErrorHandler.handle mailer, message, error, action, args
 }
-
-# Wrap devise email calls in the current locale for the user being emailed
-# and in case of a new user, use the site's locale
-# Also add resque-lock-timeout
-module Devise
-  module Async
-    module Backend
-      class Resque < Base
-        # Use ::Resque to get the real resque namespace from the outer scope
-        # since this class is named Resque >.<
-        extend ::Resque::Plugins::LockTimeout
-        extend Mconf::LocaleControllerModule
-
-        def self.perform(*args)
-          klass = args[1].constantize
-          record = klass.find(args[2])
-          I18n.with_locale(get_user_locale(record, nil)) do
-            new.perform(*args)
-          end
-        end
-
-      end
-    end
-  end
-end

--- a/config/seeds.yml
+++ b/config/seeds.yml
@@ -18,7 +18,7 @@ site:
   domain: "localhost:3000"
   smtp_login: ""
   smtp_password: ""
-  smtp_server: ""
+  smtp_server: "dev_mailer"
   smtp_domain: "localhost"
   smtp_sender: "fake-email@mconf.org"
   smtp_use_tls: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,7 @@ params = { # smtp configs for gmail
   "domain" => 'mconf-example.com'
 }
 params.merge!(config["site"])
-params[:smtp_sender] ||= params[:smtp_login]
+params['smtp_sender'] ||= params['smtp_login']
 
 if Site.count > 0
   Site.current.update_attributes params

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,8 +83,9 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
 
-  # TODO: set to false only to send emails with devise-async and capybara, see http://stackoverflow.com/questions/16732060/devise-async-sidekiq-rspec-integration-spec-fails
-  #   use databasecleaner or disable this only in the specific features that need it
+  # TODO: set to false only to send emails with devise-async and capybara
+  # see http://stackoverflow.com/questions/16732060/devise-async-sidekiq-rspec-integration-spec-fails
+  # use databasecleaner or disable this only in the specific features that need it
   config.use_transactional_fixtures = false
 
   # Make the rails routes avaiable in all specs


### PR DESCRIPTION
- Remove gem `devise-async`;

- Remove the module `:async` from `user.rb`;

- The method `devise_mail()` in `devise_mailer.rb` override the default method used by devise to set the user's locale;

- The method `send_devise_notification()` in `user.rb` override a devise's method to send emails using a queue system.