### PR TITLE
ELOSP-867: removes the 'mconf_custom_language' metadata no longer used

### DIFF
--- a/config/initializers/bigbluebutton_rails.rb
+++ b/config/initializers/bigbluebutton_rails.rb
@@ -43,8 +43,6 @@ BigbluebuttonRails.configure do |config|
       # Add custom metadata join calls
       include Mconf::LocaleControllerModule
       opts = {
-        # FIXME: remove after team Live update bbb to version 2.4
-        "userdata-mconf_custom_language": Mconf::LocaleControllerModule.get_user_locale(user),
         "userdata-bbb_override_default_locale": Mconf::LocaleControllerModule.get_user_locale(user),
       }
       opts

--- a/spec/lib/bigbluebutton_rails.rb
+++ b/spec/lib/bigbluebutton_rails.rb
@@ -95,8 +95,6 @@ describe BigbluebuttonRails do
             let(:user) { FactoryGirl.create(:user, locale: user_locale) }
             let(:join_options) { target.get_join_options.call(room, user, {}) }
             let(:locale) { Mconf::LocaleControllerModule.get_user_locale(user) }
-            # FIXME: remove after team Live update bbb to version 2.4
-            it { expect(join_options[:"userdata-mconf_custom_language"]).to eql(locale) }
             it { expect(join_options[:"userdata-bbb_override_default_locale"]).to eql(locale) }
           end
         end


### PR DESCRIPTION
- The `mconf_custom_language` metadata was replaced with `bbb_override_default_locale` and now has been removed